### PR TITLE
Add a PaymentSuccess type

### DIFF
--- a/ApiClient.php
+++ b/ApiClient.php
@@ -80,6 +80,7 @@ class ApiClient
         'paymentReference'        => '\CL\DocData\Component\OrderApi\Type\PaymentReference',
         'paymentRequestInput'     => '\CL\DocData\Component\OrderApi\Type\PaymentRequestInput',
         'paymentResponse'         => '\CL\DocData\Component\OrderApi\Type\PaymentResponse',
+        'paymentSuccess'          => '\CL\DocData\Component\OrderApi\Type\PaymentSuccess',
         'quantity'                => '\CL\DocData\Component\OrderApi\Type\Quantity',
         'refund'                  => '\CL\DocData\Component\OrderApi\Type\Refund',
         'refundError'             => '\CL\DocData\Component\OrderApi\Type\RefundError',

--- a/Type/PaymentResponse.php
+++ b/Type/PaymentResponse.php
@@ -10,7 +10,7 @@ namespace CL\DocData\Component\OrderApi\Type;
 class PaymentResponse extends AbstractObject
 {
     /**
-     * @var mixed
+     * @var PaymentSuccess
      */
     protected $paymentSuccess;
 
@@ -23,4 +23,20 @@ class PaymentResponse extends AbstractObject
      * @var mixed
      */
     protected $paymentError;
+
+    /**
+     * @return PaymentSuccess
+     */
+    public function getPaymentSuccess()
+    {
+        return $this->paymentSuccess;
+    }
+
+    /**
+     * @param PaymentSuccess $paymentSuccess
+     */
+    public function setPaymentSuccess(PaymentSuccess $paymentSuccess)
+    {
+        $this->paymentSuccess = $paymentSuccess;
+    }
 }

--- a/Type/PaymentSuccess.php
+++ b/Type/PaymentSuccess.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace CL\DocData\Component\OrderApi\Type;
+
+/**
+ * DocDataPayments PaymentSuccess class
+ *
+ * @author Roel van Duijnhoven <roel@jouwweb.nl>
+ */
+class PaymentSuccess extends AbstractObject
+{
+    /**
+     * @var string
+     */
+    protected $status;
+
+    /**
+     * @var integer
+     */
+    protected $id;
+
+    /**
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * @param string $status
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+}


### PR DESCRIPTION
This PR properly adds the paymentSuccess type that the PaymentResponse composes. Previously was a stdClass and was inaccessible.

When you create a payment it could be directly cancelled (eg. mandate has been revoked). After this has been merged one can check for this using $response->getPaymentReport()->getPaymentSuccess()->getStatus().